### PR TITLE
Have `apt` update its cache only every 24 hours

### DIFF
--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -12,7 +12,10 @@
   when: corda_java == "openjdk"
 
 - name: Update APT cache
-  apt: update_cache=yes
+  apt:
+    update_cache: yes
+    cache_valid_time: '{{ 60*60*24 }}' # in seconds, and cache is valid for one day
+
 
 - name: Install os packages
   apt:


### PR DESCRIPTION
see
https://docs.ansible.com/ansible/latest/modules/apt_module.html#apt-module

It is sort of an optimization, however it is worth noting there might be many roles which could try to make sure `apt` has a fresh cache from repositories and without that functionality it could be executed many times (for each such role)