### PR TITLE
Updates Apt keyserver location

### DIFF
--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Zulu.org JDK repository key
   apt_key:
-    keyserver: keyserver.ubuntu.com
+    url: https://assets.azul.com/files/0xB1998361219BD9C9.txt
     id: "0xB1998361219BD9C9"
   when: corda_java == "openjdk"
 

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Zulu.org JDK repository key
   apt_key:
-    url: "hkp://keyserver.ubuntu.com:80"
+    url: "https://assets.azul.com/files/0xB1998361219BD9C9.txt"
     id: "0xB1998361219BD9C9"
   when: corda_java == "openjdk"
 

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Zulu.org JDK repository key
   apt_key:
-    url: https://assets.azul.com/files/0xB1998361219BD9C9.txt
+    url: "hkp://keyserver.ubuntu.com:80"
     id: "0xB1998361219BD9C9"
   when: corda_java == "openjdk"
 


### PR DESCRIPTION
I've updated keyserver as per the following links:

- https://docs.azul.com/zing/zing11-quick-start-ubuntu.htm (this works)
- https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachAPTRepositoryUbuntuOrDebianSys.htm (hkp doesn't)

As with the current configuration it is basically stuck.

I've tested it and it works better.

```
ASK [./corda-ansible : Add Zulu.org JDK repository key] **********************************************************
changed: [localhost]

TASK [./corda-ansible : Add Zulu.org JDK repository] **************************************************************
changed: [localhost]

TASK [./corda-ansible : Update APT cache] *************************************************************************
ok: [localhost]
```