### PR TITLE
Fixes syntax for version checks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
     owner: "{{ corda_user }}"
     group: "{{ corda_user }}"
     mode: 0755
-  when: corda_version|version_compare('3','>=')
+  when: corda_version is version('3','>=')
 
 # For jars from Maven Central
 - include: source_maven.yml

--- a/tasks/source_maven.yml
+++ b/tasks/source_maven.yml
@@ -9,7 +9,7 @@
     repository_url: "http://repo1.maven.org/maven2"
   loop:
     - corda
-  when: corda_version|version_compare('3.1','>=')
+  when: corda_version is version('3.1','>=')
   notify:
     - start corda
   # module has a bug and repository_url is necessary for now


### PR DESCRIPTION
This fixes the following error:

```
...
TASK [./corda-ansible : Get corda jars from Maven Central (post 3.0)] *********************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'corda_version|version_compare('3.1','>=')' failed. The error was: template error while templating string: no filter named 'version_compare'. String: {% if corda_version|version_compare('3.1','>=') %} True {% else %} False {% endif %}\n\nThe error appears to be in '/root/corda-ansible/tasks/source_maven.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Get corda jars from Maven Central (post 3.0)\n  ^ here\n"}
$ ansible --version
ansible 2.9.7
```

Fix based on this commit: https://github.com/systemli/ansible-role-sshd/pull/24/files

Tested and it works.